### PR TITLE
Allow REST

### DIFF
--- a/generateCacheKeyFromRequest.go
+++ b/generateCacheKeyFromRequest.go
@@ -15,7 +15,7 @@ func generateCacheKeyFromRequest(req *http.Request) (string, error) {
 	}
 
 	h := sha256.New()
-	h.Write([]byte(string(reqBody)))
+	h.Write(append(reqBody, []byte(req.URL.Path)...))
 	cacheHex := h.Sum(nil)
 	cacheKey := hex.EncodeToString(cacheHex)
 

--- a/mux.go
+++ b/mux.go
@@ -50,7 +50,7 @@ func getMux(proxy *httputil.ReverseProxy) *http.ServeMux {
 
 		if err == redis.Nil {
 			// Cache miss
-			fmt.Println("Cache miss. Calling Github GraphQL API")
+			fmt.Println("Cache miss. Calling Github API")
 			proxy.ServeHTTP(w, r)
 		} else if err != nil {
 			// Error occurred while fetching from cache

--- a/transport.go
+++ b/transport.go
@@ -18,7 +18,6 @@ type transport struct {
 func prepareRequestForRedirect(req *http.Request) {
 	// Set the URL path to the Github GraphQL endpoint
 	req.URL.Scheme = "https"
-	req.URL.Path = "/graphql"
 
 	// Set the Host Header AND the URL Host to the GraphQL API endpoint (https://github.com/golang/go/issues/28168)
 	req.Host = "api.github.com"


### PR DESCRIPTION
Felt like diving into Go a bit today and try to enable REST. Is this really all that is needed? Works on my machine at least. Didn't touch [this function](https://github.com/OpenQDev/OpenQ-Github-Proxy/blob/cc3d86ecc6c9e2f8550e1b1d72be6946bf73bc07/transport.go#L43-L78). I guess it also needs adjustments?

Frontend/clients need to be adjusted then to call `/graphql` instead of `/` or maybe `/` can default to `/graphql`.